### PR TITLE
管道通信类，为了不影响之前回显功能设置管道 open 为非阻塞，这样会有一个问题就是程序运行之前要先起输出端管道，比如 cat outpu…

### DIFF
--- a/myZinx/FifoChannel.cpp
+++ b/myZinx/FifoChannel.cpp
@@ -1,0 +1,49 @@
+#include "FifoChannel.h"
+#include <unistd.h>
+#include <fcntl.h>
+#include <iostream>
+
+FifoChannel::FifoChannel(std::string _file, bool _isRead)
+    : m_fifoName(_file), m_isRead(_isRead)
+{
+}
+
+FifoChannel::~FifoChannel()
+{
+}
+
+int FifoChannel::GetFd()
+{
+    return m_fd;
+}
+
+void FifoChannel::DataProcess(std::string _input)
+{
+    if(m_outChannel!=nullptr){
+        m_outChannel->DataSendOut(_input);
+    }
+}
+
+bool FifoChannel::Init()
+{
+    bool bRet = false;
+    // 打开文件
+    int flag = O_RDONLY;
+    if (m_isRead == false) {
+        flag = O_WRONLY;
+    }
+    int fd = open(m_fifoName.c_str(), flag | O_NONBLOCK);
+    if (fd >= 0) {
+        m_fd = fd;
+        bRet = true;
+    }
+    // std::cout << (bRet ? "success" : "fail") << std::endl;
+    return bRet;
+}
+
+void FifoChannel::Fini()
+{
+    if (m_fd >= 0) {
+        close(m_fd);
+    }
+}

--- a/myZinx/FifoChannel.h
+++ b/myZinx/FifoChannel.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "IChannel.h"
+#include <string>
+
+class FifoChannel :
+    public IChannel
+{
+private:
+    std::string m_fifoName;
+    // 在 Init() 函数中打开文件中被赋值, 该函数在构造函数中被调用
+    int m_fd = -1;
+    // 该管道是否是读端
+    bool m_isRead = true;
+    FifoChannel* m_outChannel = nullptr;
+
+public:
+    FifoChannel(std::string _file, bool _isRead);
+    virtual ~FifoChannel();
+
+    // 通过 IChannel 继承
+    virtual int GetFd() override;
+    virtual void DataProcess(std::string _input) override;
+
+    // 通过 IChannel 继承
+    virtual bool Init() override;
+    virtual void Fini() override;
+
+public:
+    void SetOutChannel(FifoChannel* _pChannel) {
+        m_outChannel = _pChannel;
+    }
+};
+

--- a/myZinx/IChannel.cpp
+++ b/myZinx/IChannel.cpp
@@ -45,5 +45,10 @@ std::string IChannel::ReadFd()
 
 void IChannel::WriteFd(std::string _output)
 {
-	write(this->GetFd(), _output.c_str(), _output.size());
+	// 这样写有隐患， 如果 _output 有 \0， c_str 后会提前结束
+	// write(this->GetFd(), _output.c_str(), _output.size());
+	char* pout = (char*)malloc(_output.size());
+	_output.copy(pout, _output.size(), 0);
+	write(this->GetFd(), pout, _output.size());
+	free(pout);
 }

--- a/myZinx/IChannel.h
+++ b/myZinx/IChannel.h
@@ -7,6 +7,10 @@ public:
 	IChannel();
 	virtual ~IChannel();
 
+	// 在 kernel 中 AddChannel() 中调用
+	virtual bool Init() = 0;
+	// 去初始化， 在 kernel 中 DelChannel() 中调用
+	virtual void Fini() = 0;
 	virtual int GetFd() = 0;
 	virtual void DataProcess(std::string _input) = 0;
 
@@ -14,7 +18,7 @@ public:
 	void WriteFd(std::string _output);
 	// 不直接调用 WriteFd， 只是存到缓存 m_buffer 并修改 epoll, 等到 epoll 返回再发, 通用函数
 	void DataSendOut(std::string _output);
-	// 向外刷出缓存数据 内部调用 WriteFd 这个才是真正的输出    函数
+	// 向外刷出缓存数据 内部调用 WriteFd 这个才是真正的输出函数
 	void FlushOut();
 
 private:

--- a/myZinx/StdinChannel.cpp
+++ b/myZinx/StdinChannel.cpp
@@ -21,3 +21,12 @@ void StdinChannel::DataProcess(std::string _input)
 	// 将数据回显到标准输出 -> 需要调用标准输出通道对象的 SendOut 函数
 	m_outChannel->DataSendOut(_input);
 }
+
+bool StdinChannel::Init()
+{
+	return true;
+}
+
+void StdinChannel::Fini()
+{
+}

--- a/myZinx/StdinChannel.h
+++ b/myZinx/StdinChannel.h
@@ -24,5 +24,9 @@ public:
 	StdoutChannel* GetOutChannel() {
 		return m_outChannel;
 	}
+
+	// Í¨¹ý IChannel ¼Ì³Ð
+	virtual bool Init() override;
+	virtual void Fini() override;
 };
 

--- a/myZinx/StdoutChannel.cpp
+++ b/myZinx/StdoutChannel.cpp
@@ -18,3 +18,12 @@ int StdoutChannel::GetFd()
 void StdoutChannel::DataProcess(std::string _input)
 {
 }
+
+bool StdoutChannel::Init()
+{
+	return true;
+}
+
+void StdoutChannel::Fini()
+{
+}

--- a/myZinx/StdoutChannel.h
+++ b/myZinx/StdoutChannel.h
@@ -10,5 +10,9 @@ public:
     // 通过 IChannel 继承
     virtual int GetFd() override;
     virtual void DataProcess(std::string _input) override;
+
+    // 通过 IChannel 继承
+    virtual bool Init() override;
+    virtual void Fini() override;
 };
 

--- a/myZinx/ZinxKernel.cpp
+++ b/myZinx/ZinxKernel.cpp
@@ -74,13 +74,16 @@ void ZinxKernel::ModChannelDelOut(IChannel* _pChannel)
 
 void ZinxKernel::AddChannel(IChannel* _pChannel)
 {
-	struct epoll_event stEvent;
-	stEvent.events = EPOLLIN;
-	stEvent.data.ptr = _pChannel;
-	epoll_ctl(m_epollFd, EPOLL_CTL_ADD, _pChannel->GetFd(), &stEvent);
+	if (_pChannel->Init() == true) {
+		struct epoll_event stEvent;
+		stEvent.events = EPOLLIN;
+		stEvent.data.ptr = _pChannel;
+		epoll_ctl(m_epollFd, EPOLL_CTL_ADD, _pChannel->GetFd(), &stEvent);
+	}
 }
 
 void ZinxKernel::DelChannel(IChannel* _pChannel)
 {
 	epoll_ctl(m_epollFd, EPOLL_CTL_DEL, _pChannel->GetFd(), NULL);
+	_pChannel->Fini();
 }

--- a/myZinx/main.cpp
+++ b/myZinx/main.cpp
@@ -2,16 +2,25 @@
 #include "ZinxKernel.h"
 #include "StdinChannel.h"
 #include "StdoutChannel.h"
+#include "FifoChannel.h"
 
 int main()
 {
+    ZinxKernel& kernel = ZinxKernel::GetInstance();
+
     StdinChannel in_channel;
     StdoutChannel out_channel;
     in_channel.SetOutChannel(&out_channel);
 
-    ZinxKernel& kernel = ZinxKernel::GetInstance();
     kernel.AddChannel(&out_channel);
     kernel.AddChannel(&in_channel);
+
+    FifoChannel fifo_in_channel("input", true);
+    FifoChannel fifo_out_channel("output", false);
+    fifo_in_channel.SetOutChannel(&fifo_out_channel);
+
+    kernel.AddChannel(&fifo_in_channel);
+    kernel.AddChannel(&fifo_out_channel);
 
     kernel.Run();
     return 0;

--- a/myZinx/myZinx.vcxproj
+++ b/myZinx/myZinx.vcxproj
@@ -75,6 +75,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClCompile Include="FifoChannel.cpp" />
     <ClCompile Include="IChannel.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="StdinChannel.cpp" />
@@ -82,6 +83,7 @@
     <ClCompile Include="ZinxKernel.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="FifoChannel.h" />
     <ClInclude Include="IChannel.h" />
     <ClInclude Include="StdinChannel.h" />
     <ClInclude Include="StdoutChannel.h" />


### PR DESCRIPTION
…t, 否则 Init() 的时候会因为非阻塞返回 false,  后续也没再调用 Init 的机会导致无法打开, 然而读端总是能立即返回 true

对于以只读方式（O_RDONLY）打开的FIFO文件，如果open调用是阻塞的（即第二个参数为O_RDONLY），除非有一个进程以写方式打开同一个FIFO，否则它不会返回；如果open调用是非阻塞的的（即第二个参数为O_RDONLY | O_NONBLOCK），则即使没有其他进程以写方式打开同一个FIFO文件，open调用将成功并立即返回。

对于以只写方式（O_WRONLY）打开的FIFO文件，如果open调用是阻塞的（即第二个参数为O_WRONLY），open调用将被阻塞，直到有一个进程以只读方式打开同一个FIFO文件为止；如果open调用是非阻塞的（即第二个参数为O_WRONLY | O_NONBLOCK），open总会立即返回，但如果没有其他进程以只读方式打开同一个FIFO文件，open调用将返回-1，并且FIFO也不会被打开。